### PR TITLE
Format in lowercase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.1.2
+
+* changed image properties analyser to downcase the image's format
+
 ## 2.1.1
 
 * add `CMYK` support using the `cmyk.icm` profile

--- a/lib/dragonfly_libvips/analysers/image_properties.rb
+++ b/lib/dragonfly_libvips/analysers/image_properties.rb
@@ -17,7 +17,7 @@ module DragonflyLibvips
         xres, yres = img.xres, img.yres
 
         {
-          'format' => content.ext,
+          'format' => content.ext.downcase,
           'width' => width,
           'height' => height,
           'xres' => xres,

--- a/lib/dragonfly_libvips/version.rb
+++ b/lib/dragonfly_libvips/version.rb
@@ -1,3 +1,3 @@
 module DragonflyLibvips
-  VERSION = '2.1.1'.freeze
+  VERSION = '2.1.2'.freeze
 end


### PR DESCRIPTION
Hey @tomasc. I thought this was a nice little change. It’s solved the same way in `dragonfly` and it helps when doing validations and checks, so you don’t have to downcase the format or check for both upper and lowercase versions (`'jpg'` and `'JPG'`).