### PR TITLE
Progressive JPGs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.3.0
+
+* add `progressive` image property
+
 ## 2.2.0
 
 * add `SUPPORTED_FORMATS` and `SUPPORTED_OUTPUT_FORMATS` and raise errors when formats are not matching

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ All processors support `input_options` and `output_options` for passing addition
 
 ```ruby
 image.encode('jpg', output_options: { Q: 50 })
+image.encode('jpg', output_options: { interlace: true }) # use interlace to generate a progressive jpg
 pdf.encode('jpg', input_options: { page: 0, dpi: 600 })
 ```
 
@@ -124,6 +125,7 @@ image.width # => 280
 image.height # => 355
 image.xres # => 72.0
 image.yres # => 72.0
+image.progressive # => true
 image.aspect_ratio # => 0.788732394366197
 image.portrait? # => true
 image.landscape? # => false

--- a/lib/dragonfly_libvips/analysers/image_properties.rb
+++ b/lib/dragonfly_libvips/analysers/image_properties.rb
@@ -20,15 +20,14 @@ module DragonflyLibvips
         xres = img.xres
         yres = img.yres
 
-        res = {
+        {
           'format' => content.ext.to_s,
           'width' => width,
           'height' => height,
           'xres' => xres,
-          'yres' => yres
+          'yres' => yres,
+          'progressive' => (content.mime_type == 'image/jpeg' && img.get('jpeg-multiscan') != 0)
         }
-        res['progressive'] = img.get('jpeg-multiscan') != 0 if content.mime_type == 'image/jpeg'
-        res
       end
     end
   end

--- a/lib/dragonfly_libvips/analysers/image_properties.rb
+++ b/lib/dragonfly_libvips/analysers/image_properties.rb
@@ -20,13 +20,15 @@ module DragonflyLibvips
         xres = img.xres
         yres = img.yres
 
-        {
+        res = {
           'format' => content.ext.to_s,
           'width' => width,
           'height' => height,
           'xres' => xres,
           'yres' => yres
         }
+        res['progressive'] = img.get('jpeg-multiscan') != 0 if content.mime_type == 'image/jpeg'
+        res
       end
     end
   end

--- a/lib/dragonfly_libvips/processors/thumb.rb
+++ b/lib/dragonfly_libvips/processors/thumb.rb
@@ -21,8 +21,8 @@ module DragonflyLibvips
         input_options['autorotate'] = input_options.fetch('autorotate', true) if content.mime_type == 'image/jpeg'
 
         if content.mime_type == 'application/pdf'
-          input_options['dpi'] = input_options.fetch('dpi', DPI) if content.mime_type == 'application/pdf'
-          input_options['page'] = input_options.fetch('page', 0) if content.mime_type == 'application/pdf'
+          input_options['dpi'] = input_options.fetch('dpi', DPI)
+          input_options['page'] = input_options.fetch('page', 0)
         else
           input_options.delete('page')
           input_options.delete('dpi')

--- a/lib/dragonfly_libvips/version.rb
+++ b/lib/dragonfly_libvips/version.rb
@@ -1,3 +1,3 @@
 module DragonflyLibvips
-  VERSION = '2.2.0'.freeze
+  VERSION = '2.3.0'.freeze
 end

--- a/test/dragonfly_libvips/analysers/image_properties_test.rb
+++ b/test/dragonfly_libvips/analysers/image_properties_test.rb
@@ -3,7 +3,12 @@ require 'test_helper'
 describe DragonflyLibvips::Analysers::ImageProperties do
   let(:app) { test_libvips_app }
   let(:analyser) { DragonflyLibvips::Analysers::ImageProperties.new }
-  let(:content) { Dragonfly::Content.new(app, SAMPLES_DIR.join('sample.png')) } # 280x355
+  let(:png) { Dragonfly::Content.new(app, SAMPLES_DIR.join('sample.png')) } # 280x355
+  let(:jpg) { Dragonfly::Content.new(app, SAMPLES_DIR.join('sample.jpg')) } # 280x355
 
-  it { analyser.call(content).must_equal('format' => 'png', 'width' => 280, 'height' => 355, 'xres' => 72.0, 'yres' => 72.0) }
+  it { analyser.call(png).must_equal('format' => 'png', 'width' => 280, 'height' => 355, 'xres' => 72.0, 'yres' => 72.0) }
+
+  describe 'jpgs' do
+    it { analyser.call(jpg)['progressive'].must_equal false }
+  end
 end

--- a/test/dragonfly_libvips/analysers/image_properties_test.rb
+++ b/test/dragonfly_libvips/analysers/image_properties_test.rb
@@ -6,7 +6,7 @@ describe DragonflyLibvips::Analysers::ImageProperties do
   let(:png) { Dragonfly::Content.new(app, SAMPLES_DIR.join('sample.png')) } # 280x355
   let(:jpg) { Dragonfly::Content.new(app, SAMPLES_DIR.join('sample.jpg')) } # 280x355
 
-  it { analyser.call(png).must_equal('format' => 'png', 'width' => 280, 'height' => 355, 'xres' => 72.0, 'yres' => 72.0) }
+  it { analyser.call(png).must_equal('format' => 'png', 'width' => 280, 'height' => 355, 'xres' => 72.0, 'yres' => 72.0, 'progressive' => false) }
 
   describe 'jpgs' do
     it { analyser.call(jpg)['progressive'].must_equal false }

--- a/test/dragonfly_libvips/processors/thumb_test.rb
+++ b/test/dragonfly_libvips/processors/thumb_test.rb
@@ -5,6 +5,7 @@ describe DragonflyLibvips::Processors::Thumb do
   let(:app) { test_libvips_app }
   let(:image) { Dragonfly::Content.new(app, SAMPLES_DIR.join('sample.png')) } # 280x355
   let(:pdf) { Dragonfly::Content.new(app, SAMPLES_DIR.join('sample.pdf')) }
+  let(:jpg) { Dragonfly::Content.new(app, SAMPLES_DIR.join('sample.jpg')) }
   let(:cmyk) { Dragonfly::Content.new(app, SAMPLES_DIR.join('sample_cmyk.jpg')) }
   let(:landscape_image) { Dragonfly::Content.new(app, SAMPLES_DIR.join('landscape_sample.png')) } # 355x280
   let(:processor) { DragonflyLibvips::Processors::Thumb.new }
@@ -79,6 +80,13 @@ describe DragonflyLibvips::Processors::Thumb do
       before { processor.call(pdf, '500x500', format: 'jpg', input_options: { page: 0 }) }
       it { pdf.must_have_width 387 }
       it { pdf.must_have_height 500 }
+    end
+  end
+
+  describe 'jpg' do
+    describe 'progressive' do
+      before { processor.call(jpg, '300x', output_options: { interlace: true }) }
+      it { (`vipsheader -f jpeg-multiscan #{jpg.file.path}`.to_i == 1).must_equal true }
     end
   end
 


### PR DESCRIPTION
* Adds a `progressive` value to the ImageProperties analyser
* Adds test for the `interlace: true` output_option in the Thumb processor

Turns out it was simply a matter of passing `interlace: true` to `output_options` for `Thumb` to work. I added a test, which albeit a bit redundant, makes sure that it works 🙂

Also added a `'progressive'` key to the `ImageProperties` analyser, which tests jpegs to see if they are progressive. Might come in handy?