### PR TITLE
Fix misspelled UnsupportedOutputFormat

### DIFF
--- a/lib/dragonfly_libvips.rb
+++ b/lib/dragonfly_libvips.rb
@@ -6,7 +6,7 @@ require 'vips'
 
 module DragonflyLibvips
   class UnsupportedFormat < RuntimeError; end
-  class UnsupportedOutputormat < RuntimeError; end
+  class UnsupportedOutputFormat < RuntimeError; end
 
   CMYK_PROFILE_PATH = File.expand_path('../vendor/cmyk.icm', __dir__)
   EPROFILE_PATH = File.expand_path('../vendor/sRGB_v4_ICC_preference.icc', __dir__)


### PR DESCRIPTION
We are missing an `F` in the definition of `UnsupportedOutputFormat`.