### PR TITLE
Update all DragonflyLibvips.symbolize_keys to new syntax

### DIFF
--- a/lib/dragonfly_libvips/processors/encode.rb
+++ b/lib/dragonfly_libvips/processors/encode.rb
@@ -38,10 +38,10 @@ module DragonflyLibvips
         output_options.delete("Q") unless /jpg|jpeg/i.match?(format.to_s)
         output_options["format"] ||= format.to_s if /gif|bmp/i.match?(format.to_s)
 
-        img = ::Vips::Image.new_from_file(content.path, DragonflyLibvips.symbolize_keys(input_options))
+        img = ::Vips::Image.new_from_file(content.path, **DragonflyLibvips.symbolize_keys(input_options))
 
         content.update(
-          img.write_to_buffer(".#{format}", DragonflyLibvips.symbolize_keys(output_options)),
+          img.write_to_buffer(".#{format}", **DragonflyLibvips.symbolize_keys(output_options)),
           "name" => "temp.#{format}",
           "format" => format
         )

--- a/lib/dragonfly_libvips/processors/extract_area.rb
+++ b/lib/dragonfly_libvips/processors/extract_area.rb
@@ -28,11 +28,11 @@ module DragonflyLibvips
         output_options.delete("Q") unless /jpg|jpeg/i.match?(format.to_s)
         output_options["format"] ||= format.to_s if /gif|bmp/i.match?(format.to_s)
 
-        img = ::Vips::Image.new_from_file(content.path, DragonflyLibvips.symbolize_keys(input_options))
+        img = ::Vips::Image.new_from_file(content.path, **DragonflyLibvips.symbolize_keys(input_options))
         img = img.extract_area(x, y, width, height)
 
         content.update(
-          img.write_to_buffer(".#{format}", DragonflyLibvips.symbolize_keys(output_options)),
+          img.write_to_buffer(".#{format}", **DragonflyLibvips.symbolize_keys(output_options)),
           "name" => "temp.#{format}",
           "format" => format
         )

--- a/lib/dragonfly_libvips/processors/rotate.rb
+++ b/lib/dragonfly_libvips/processors/rotate.rb
@@ -28,11 +28,11 @@ module DragonflyLibvips
         output_options.delete("Q") unless /jpg|jpeg/i.match?(format.to_s)
         output_options["format"] ||= format.to_s if /gif|bmp/i.match?(format.to_s)
 
-        img = ::Vips::Image.new_from_file(content.path, DragonflyLibvips.symbolize_keys(input_options))
+        img = ::Vips::Image.new_from_file(content.path, **DragonflyLibvips.symbolize_keys(input_options))
         img = img.rot("d#{rotate}")
 
         content.update(
-          img.write_to_buffer(".#{format}", DragonflyLibvips.symbolize_keys(output_options)),
+          img.write_to_buffer(".#{format}", **DragonflyLibvips.symbolize_keys(output_options)),
           "name" => "temp.#{format}",
           "format" => format
         )

--- a/lib/dragonfly_libvips/processors/thumb.rb
+++ b/lib/dragonfly_libvips/processors/thumb.rb
@@ -41,7 +41,7 @@ module DragonflyLibvips
         output_options["format"] ||= format.to_s if /gif|bmp/i.match?(format.to_s)
 
         input_options = input_options.transform_keys { |k| k.to_sym } # symbolize
-        img = ::Vips::Image.new_from_file(filename, DragonflyLibvips.symbolize_keys(input_options))
+        img = ::Vips::Image.new_from_file(filename, **DragonflyLibvips.symbolize_keys(input_options))
 
         dimensions = case geometry
                      when RESIZE_GEOMETRY then Dimensions.call(geometry, img.width, img.height)
@@ -65,10 +65,10 @@ module DragonflyLibvips
         filename += "[page=#{input_options[:page]}]" if content.mime_type == "application/pdf"
 
         thumbnail_options = thumbnail_options.transform_keys { |k| k.to_sym } # symbolize
-        thumb = ::Vips::Image.thumbnail(filename, dimensions.width.ceil, DragonflyLibvips.symbolize_keys(thumbnail_options))
+        thumb = ::Vips::Image.thumbnail(filename, dimensions.width.ceil, **DragonflyLibvips.symbolize_keys(thumbnail_options))
 
         content.update(
-          thumb.write_to_buffer(".#{format}", DragonflyLibvips.symbolize_keys(output_options)),
+          thumb.write_to_buffer(".#{format}", **DragonflyLibvips.symbolize_keys(output_options)),
           "name" => "temp.#{format}",
           "format" => format
         )


### PR DESCRIPTION
Follow-up to https://github.com/tomasc/dragonfly_libvips/pull/20

Update rest of (i.e. all) `DragonflyLibvips.symbolize_keys` calls to match new syntax